### PR TITLE
Correct name of application main class

### DIFF
--- a/examples/doran_and_parberry/project.xml
+++ b/examples/doran_and_parberry/project.xml
@@ -2,7 +2,7 @@
 <project>
 	
 	<meta title="Doran & Parberry's example" package="com.leveluplabs.example" version="1.0.0" company="LevelUpLabs" />
-	<app main="Main" path="Export" file="doran_and_parberry"/>
+	<app main="ApplicationMain" path="Export" file="doran_and_parberry"/>
 	
 	<source path="Source" />
 	


### PR DESCRIPTION
When trying to build the doran_and_parberry application, one receives the
following error:

Export/html5/haxe/ApplicationMain.hx:267: characters 7-42 : Class not found : Main

Checking the file `ApplicationMain.hx`, one sees that the class is actually
called `ApplicationMain`.  This change to the project file corrects the
error and allows the application to be built.