### PR TITLE
Mention hscript dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ Building the example project
 
 1. Read this: [Getting Started with OpenFL](http://www.openfl.org/documentation/setup/)
 2. Install Haxe and OpenFL and everything according to the above instructions
-3. Clone this repo somewhere on your hard-drive, let's call that `path/to/bazaarbot`
-4. On the command line type `haxelib dev bazaarbot path/to/bazaarbot` to add bazaarbot as a Haxe library.
-5. Open a command-line, navigate to `path/to/bazaarbot/examples/doran_and_parberry`
-6. Run `lime build flash` to compile for flash
-7. Run `lime build windows` to compile for cpp/windows (or `lime build mac` or `lime build linux`, etc)
-8. Run `lime build html5` to compile for html5
-9. Binary executables will appear in the Export/ folder
-10. Substitute `lime test` instead of `lime build` if you want to build AND immediately run the result.
+3. Install the `hscript` library (a dependency of bazaarBot): `haxelib install hscript`
+4. Clone this repo somewhere on your hard-drive, let's call that `path/to/bazaarbot`
+5. On the command line type `haxelib dev bazaarbot path/to/bazaarbot` to add bazaarbot as a Haxe library.
+6. Open a command-line, navigate to `path/to/bazaarbot/examples/doran_and_parberry`
+7. Run `lime build flash` to compile for flash
+8. Run `lime build windows` to compile for cpp/windows (or `lime build mac` or `lime build linux`, etc)
+9. Run `lime build html5` to compile for html5
+10. Binary executables will appear in the `Export/` folder
+11. Substitute `lime test` instead of `lime build` if you want to build AND immediately run the result.
 


### PR DESCRIPTION
Running `haxelib dev bazaarbot path/to/bazaarbot` aborted because the
`hscript` library wasn't installed.  This commit mentiones `hscript` as a
dependency in the README and updates the ordered list numbers appropriately.