### PR TITLE
Accurately count round numbers when doing more than one at a time

### DIFF
--- a/bazaarbot/Market.hx
+++ b/bazaarbot/Market.hx
@@ -92,8 +92,8 @@ class Market
 					signalBankrupt.dispatch(this, agent);
 				}
 			}
+			_roundNum++;
 		}
-		_roundNum++;
 	}
 
 	public function ask(offer:Offer):Void


### PR DESCRIPTION
The _roundNum variable is not in the for loop that iterates through the number of rounds to simulate, using the "benchmark" button will break the count